### PR TITLE
Faster predict & add ref to torpor paper

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -7,3 +7,5 @@
 ^\.travis\.yml$
 ^codecov\.yml$
 ^README\.Rmd$
+vignettes/figure
+vignettes/cache

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -28,19 +28,18 @@ Encoding: UTF-8
 LazyData: true
 SystemRequirements: jags
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.1.1
+RoxygenNote: 7.2.3
 Imports: jagsUI, 
         ggplot2,
         truncnorm, 
         dplyr, 
         magrittr,
         overlapping, 
-        knitr,
-        rmarkdown, 
         lmtest, 
         rlang
 VignetteBuilder: knitr
 Suggests: 
     testthat (>= 2.1.0),
     covr,
-    markdown
+    rmarkdown,
+    knitr

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: torpor
 Type: Package
 Title: Assigning metabolic rate measurements to torpor and euthermia in heterothermic endotherms  
-Version: 0.4
+Version: 0.41
 Authors@R: 
     c(person(given = "Colin",
              family = "Vullioud",

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -18,7 +18,8 @@ Description: This package enables the assignment of M to torpor, euthermia.
   during euthermic rest and torpor along Ta, including resting metabolic rate 
   within the TNZ.
   This package is aimed to support any physiologist working in thermal energetics.
-  More information can be found on the companion article Fasel et al. (in prep) 
+  More information can be found on the companion article Fasel et al. 
+  (Biol Open 15 April 2022; 11 (4): bio059064. doi: https://doi.org/10.1242/bio.059064) 
   and in the vignettes.
   This package is center around the tor_fit() function which enables to fit mixture
   models on metabolic rates data using Bayesian inference.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+# torpor 0.41
+* tor_predict() gain an argument CI, default is TRUE and does not change previous behaviour; when CI = FALSE the function does not return prediction intervals but it computes the predicted values ca. 2000 times faster.
+
 # torpor 0.4
 * Add common methods, print, summary, plot. 
 * Tlc can now be independently estimated from MTNZ.  

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 # torpor 0.41
-* tor_predict() gain an argument CI, default is TRUE and does not change previous behaviour; when CI = FALSE the function does not return prediction intervals but it computes the predicted values ca. 2000 times faster.
+* Add citation of published paper in DESCRIPTION.
+* The function tor_predict() gains the argument `CI`. The default value for `CI` is TRUE and does not change previous behaviour. When `CI = FALSE` the function does not return prediction intervals, but it computes the predicted values ca. 2000 times faster.
 
 # torpor 0.4
 * Add common methods, print, summary, plot. 

--- a/R/tor_predict.R
+++ b/R/tor_predict.R
@@ -116,7 +116,9 @@ tor_predict <- function(tor_obj, Ta, CI = TRUE){
                         upr_95 = Y975_b,
                         lwr_95 = Y025_b)
   if (!CI) {
-    # specific filtering needed since we create Mtnz unconditionally in the simple case
+    # specific filtering needed since we create outputs unconditionally in the simple case
+    out_eut <- out_eut[out_eut$Ta < Tlc, ]
+    out_tor <- out_tor[out_tor$Ta < Tlc, ]
     out_Mtnz <- out_Mtnz[out_Mtnz$Ta >= Tlc, ]
   }
 

--- a/R/torpor-package.R
+++ b/R/torpor-package.R
@@ -9,7 +9,8 @@
 #'of M during rest and torpor along Ta, including resting metabolic rate within the TNZ.
 #'
 #'This package is aimed to support any physiologist working in thermal energetics.
-#'More information can be found on the companion article Fasel et al. (in prep)
+#'More information can be found on the companion article Fasel et al.
+#'(Biol Open 15 April 2022; 11 (4): bio059064. doi: https://doi.org/10.1242/bio.059064)
 #'and in the vignettes.
 #'
 #'This package is center around the [tor_fit()] function which enables to fit

--- a/README.Rmd
+++ b/README.Rmd
@@ -34,7 +34,7 @@ remotes::install_github("vullioud/torpor", build_vignettes = TRUE)
  
 ## Where can you find more about torpor?
 
-You can learn more about the goal and the theory behind the package in the companion article (Fasel et al., in prep). And you will find an example in the vignettes of the package. You can access it directly from R by typing: 
+You can learn more about the goal and the theory behind the package in the companion article (Fasel et al., Biol Open 15 April 2022; 11 (4): bio059064. doi: https://doi.org/10.1242/bio.059064). And you will find an example in the vignettes of the package. You can access it directly from R by typing: 
 ```{r eval=FALSE, include=TRUE}
 browseVignettes("torpor")
 ```

--- a/README.md
+++ b/README.md
@@ -40,9 +40,10 @@ remotes::install_github("vullioud/torpor", build_vignettes = TRUE)
 ## Where can you find more about torpor?
 
 You can learn more about the goal and the theory behind the package in
-the companion article (Fassel et al., in prep). And you will find an
-example in the vignettes of the package. You can access it directly from
-R by typing:
+the companion article (Fasel et al., Biol Open 15 April 2022; 11 (4):
+bio059064. doi: <https://doi.org/10.1242/bio.059064>). And you will find
+an example in the vignettes of the package. You can access it directly
+from R by typing:
 
 ``` r
 browseVignettes("torpor")
@@ -51,5 +52,5 @@ browseVignettes("torpor")
 ## How can you help ?
 
 Torpor is still in its infancy and despite numerous testing it is
-possible that bugs appears. You can help us by reporting bugs or request
+possible that bugs appear. You can help us by reporting bugs or request
 new features.

--- a/man/tor_predict.Rd
+++ b/man/tor_predict.Rd
@@ -4,12 +4,14 @@
 \alias{tor_predict}
 \title{Model predictions}
 \usage{
-tor_predict(tor_obj, Ta)
+tor_predict(tor_obj, Ta, CI = TRUE)
 }
 \arguments{
 \item{tor_obj}{a fitted model from \code{\link[=tor_fit]{tor_fit()}}}
 
 \item{Ta}{a vector of temperature}
+
+\item{CI}{whether or not to compute prediction intervals (default = TRUE, which reduces the speed of computation noticeably for large jobs)}
 }
 \value{
 a data.frame
@@ -18,12 +20,18 @@ a data.frame
 \code{\link[=tor_predict]{tor_predict()}} The function provides the predicted M and 95\% credible interval
 boundaries at a defined Ta given a certain model, in euthermic and/or torpid state.
 }
+\details{
+Note that the predictions are computed slightly differently depending on whether one uses \code{CI = TRUE} or \code{CI = FALSE}.
+In the former case (the default), for each value of Ta, one prediction is computed for every single iteration of the posteriors and the median value of these predictions is then computed.
+In the latter case, for each value of Ta, a single prediction is directly computed by assuming that parameters equate their median values from the corresponding posterior distribution.
+}
 \examples{
 \dontrun{
 test_mod <- tor_fit(M = test_data2[,2],
-                   Ta = test_data2[, 1],
-                   fitting_options = list(nc = 1, nb = 3000, ni = 5000))
+                    Ta = test_data2[, 1],
+                    fitting_options = list(nc = 1, nb = 3000, ni = 5000))
 tor_predict(test_mod, Ta = 10:35)
+tor_predict(test_mod, Ta = 10:35, CI = FALSE)
 }
 }
 \seealso{

--- a/man/torpor.Rd
+++ b/man/torpor.Rd
@@ -15,7 +15,8 @@ of M during rest and torpor along Ta, including resting metabolic rate within th
 }
 \details{
 This package is aimed to support any physiologist working in thermal energetics.
-More information can be found on the companion article Fasel et al. (in prep)
+More information can be found on the companion article Fasel et al.
+(Biol Open 15 April 2022; 11 (4): bio059064. doi: https://doi.org/10.1242/bio.059064)
 and in the vignettes.
 
 This package is center around the \code{\link[=tor_fit]{tor_fit()}} function which enables to fit


### PR DESCRIPTION
This PR fixes #5 and #6.
I also fixed some warnings and notes in R CMD check.

The main point was to increase the speed of `tor_predict()` calls that do not require the computation of CI.
When the newly added argument `CI` is set to FALSE, computation are now ca. 2000 faster (in a test example):

``` r
library(torpor)
#> 
#> Torpor version: 0.41 is loaded
#> Run: vignette('example') or browseVignettes('torpor') for an example
#> Find more information about the model in the companion article
set.seed(1)
test_mod <- tor_fit(Ta = test_data2$Ta, M = test_data2$VO2ms,
                    fitting_options = list(parallel = TRUE, ni = 500, nt = 2,
                    nb = 200), confidence = 0.9)
#> Mtnz and Tlc are being estimated from the data
#> Warning in estimate_Tlc_Mtnz(Ta = Ta, M = Y, Mtnz = Mtnz, fitting_options =
#> fitting_options): Mtnz computed on less than 10 points
#> Warning in tor_fit(Ta = test_data2$Ta, M = test_data2$VO2ms, fitting_options =
#> list(parallel = TRUE, : Rhat > 1.1 on parameter: intr
#> Warning in tor_fit(Ta = test_data2$Ta, M = test_data2$VO2ms, fitting_options =
#> list(parallel = TRUE, : Rhat > 1.1 on parameter: Tt
#> Warning in tor_fit(Ta = test_data2$Ta, M = test_data2$VO2ms, fitting_options =
#> list(parallel = TRUE, : Rhat > 1.1 on parameter: Tbt
#> $params
#>    parameter   mean CI_2.5 median CI_97.5  Rhat
#> 1       tau1  0.187  0.123  0.184   0.264 1.003
#> 2       tau2  0.455  0.350  0.446   0.577 1.005
#> 3       tau3  0.145  0.098  0.139   0.228 1.006
#> 4       inte  7.096  6.766  7.097   7.411 1.016
#> 5       intc  0.071  0.055  0.068   0.107 1.028
#> 6       intr  0.793 -0.027  0.857   1.153 1.129
#> 7      betat -0.171 -0.182 -0.171  -0.161 1.016
#> 8      betac  0.099  0.081  0.100   0.110 1.022
#> 9         Tt  4.018 -0.754  4.365   5.980 1.122
#> 10       TMR  0.106  0.090  0.105   0.133 1.042
#> 11        Mr  1.493  1.089  1.514   1.751 1.046
#> 12       Tbe 41.406 40.808 41.392  42.087 1.017
#> 13       Tbt  4.637 -0.154  4.985   6.606 1.124
#> 14       Tlc 30.766 28.726 30.936  33.402 2.200
#> 15      Mtnz  1.793  1.541  1.746   2.045    NA
#> 
#> $ppo
#>   name  ppo
#> 1   Mr 37.8
#> 2  TMR  4.0

test1 <- tor_predict(test_mod, rep(14:15, 10000))
test2 <- tor_predict(test_mod, rep(14:15, 10000), CI = FALSE)
head(test1)
#>   Ta assignment      pred    upr_95    lwr_95
#> 1 14     Torpor 0.2785948 0.3452797 0.2383870
#> 2 15     Torpor 0.3077218 0.3789143 0.2634747
#> 3 14     Torpor 0.2785948 0.3452797 0.2383870
#> 4 15     Torpor 0.3077218 0.3789143 0.2634747
#> 5 14     Torpor 0.2785948 0.3452797 0.2383870
#> 6 15     Torpor 0.3077218 0.3789143 0.2634747
head(test2)
#>   Ta assignment      pred upr_95 lwr_95
#> 1 14     Torpor 0.2765965     NA     NA
#> 2 15     Torpor 0.3056501     NA     NA
#> 3 14     Torpor 0.2765965     NA     NA
#> 4 15     Torpor 0.3056501     NA     NA
#> 5 14     Torpor 0.2765965     NA     NA
#> 6 15     Torpor 0.3056501     NA     NA
tail(test1)
#>       Ta assignment     pred   upr_95   lwr_95
#> 39995 14  Euthermia 4.696704 4.868444 4.515604
#> 39996 15  Euthermia 4.525240 4.686840 4.354833
#> 39997 14  Euthermia 4.696704 4.868444 4.515604
#> 39998 15  Euthermia 4.525240 4.686840 4.354833
#> 39999 14  Euthermia 4.696704 4.868444 4.515604
#> 40000 15  Euthermia 4.525240 4.686840 4.354833
tail(test2)
#>       Ta assignment     pred upr_95 lwr_95
#> 39995 14  Euthermia 4.696704     NA     NA
#> 39996 15  Euthermia 4.525240     NA     NA
#> 39997 14  Euthermia 4.696704     NA     NA
#> 39998 15  Euthermia 4.525240     NA     NA
#> 39999 14  Euthermia 4.696704     NA     NA
#> 40000 15  Euthermia 4.525240     NA     NA

microbenchmark::microbenchmark(test1 <- tor_predict(test_mod, rep(14:15, 10000)),
                               test2 <- tor_predict(test_mod, rep(14:15, 10000), CI = FALSE), times = 2)
#> Unit: milliseconds
#>                                                           expr         min
#>              test1 <- tor_predict(test_mod, rep(14:15, 10000)) 9576.275831
#>  test2 <- tor_predict(test_mod, rep(14:15, 10000), CI = FALSE)    4.940958
#>           lq        mean      median          uq         max neval cld
#>  9576.275831 9621.333524 9621.333524 9666.391216 9666.391216     2  a 
#>     4.940958    5.412638    5.412638    5.884318    5.884318     2   b
```

<sup>Created on 2023-06-12 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>
